### PR TITLE
Add OData Schema parser to Cypher

### DIFF
--- a/ODataSchema2Cypher/__init__.py
+++ b/ODataSchema2Cypher/__init__.py
@@ -1,11 +1,49 @@
 import requests
 from falkordb import FalkorDB
+import xml.etree.ElementTree as ET
 
-# Call an HTTP GET request to the OData service
-def main():
-
+def parse_odata_schema(schema):
     """
-    This function calls an OData service and prints the response.
+    This function parses the OData schema and returns entities and relationships.
+    """
+    entities = {}
+    relationships = []
+
+    root = ET.fromstring(schema)
+    for entity_type in root.findall(".//EntityType"):
+        entity_name = entity_type.get("Name")
+        entities[entity_name] = {
+            "properties": [prop.get("Name") for prop in entity_type.findall(".//Property")],
+            "navigation_properties": [nav.get("Name") for nav in entity_type.findall(".//NavigationProperty")]
+        }
+
+    for entity_name, entity in entities.items():
+        for nav_prop in entity["navigation_properties"]:
+            relationships.append((entity_name, nav_prop))
+
+    return entities, relationships
+
+def generate_cypher_queries(entities, relationships):
+    """
+    This function generates Cypher queries for entities and relationships.
+    """
+    queries = []
+
+    for entity_name, entity in entities.items():
+        query = f"CREATE (n:{entity_name} {{"
+        query += ", ".join([f"{prop}: ${{prop}}" for prop in entity["properties"]])
+        query += "})"
+        queries.append(query)
+
+    for relationship in relationships:
+        query = f"MATCH (a:{relationship[0]}), (b:{relationship[1]}) CREATE (a)-[:RELATED_TO]->(b)"
+        queries.append(query)
+
+    return queries
+
+def main():
+    """
+    This function calls an OData service, parses the schema, and generates Cypher queries.
     """
 
     # Connect to FalkorDB
@@ -15,8 +53,15 @@ def main():
     # Call the OData service pass user name and password
     response = requests.get('https://demoen.softsolutions.co.il/odata/Priority/tabula.ini/demo/$metadata', auth=('api', '12345'))
 
-    # Print the response
-    print(response.text)
+    # Parse the OData schema
+    entities, relationships = parse_odata_schema(response.text)
+
+    # Generate Cypher queries
+    cypher_queries = generate_cypher_queries(entities, relationships)
+
+    # Print the Cypher queries
+    for query in cypher_queries:
+        print(query)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #1

Add functions to parse OData schema and generate Cypher queries.

* Add `parse_odata_schema` function to parse Entities and Relationships from OData Schema.
* Add `generate_cypher_queries` function to generate Cypher queries for each Entity and relationship.
* Modify `main` function to call `parse_odata_schema` and `generate_cypher_queries`.
* Print the generated Cypher queries.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/FalkorDB/ODataSchema2Cypher/pull/2?shareId=312773a7-e54b-4d6b-a584-1575fa163832).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - Added functionality to parse OData schemas
    - Introduced ability to generate Cypher queries from parsed OData schemas
- **Improvements**
    - Enhanced main function to process OData service responses more comprehensively
    - Added schema parsing and query generation capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->